### PR TITLE
Add message to assertion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,13 +15,16 @@ const sortDeep = (object) => {
 
 module.exports = (chai, utils) => {
   const { Assertion } = chai;
-  utils.addMethod(Assertion.prototype, 'equalInAnyOrder', function equalInAnyOrder(b) {
+  utils.addMethod(Assertion.prototype, 'equalInAnyOrder', function equalInAnyOrder(b, m) {
     const a = this.__flags.object;
-    const { negate } = this.__flags;
+    const { negate, message } = this.__flags;
+
+    const msg = m || message;
+
     if (negate) {
-      new Assertion(sortDeep(a)).to.not.deep.equal(sortDeep(b));
+      new Assertion(sortDeep(a), msg).to.not.deep.equal(sortDeep(b));
     } else {
-      new Assertion(sortDeep(a)).to.deep.equal(sortDeep(b));
+      new Assertion(sortDeep(a), msg).to.deep.equal(sortDeep(b));
     }
   });
 };

--- a/src/tests/deepEqualInAnyOrder.js
+++ b/src/tests/deepEqualInAnyOrder.js
@@ -271,4 +271,22 @@ describe('equalInAnyOrder', () => {
     };
     expectToNotDeepEqualInAnyOrder(a, b);
   });
+
+  it('prepends message from expect', () => {
+    expect(
+      () => expect(true, 'message').to.deep.equalInAnyOrder(false),
+    ).to.throw().and.satisfy(e => /^message:/.test(e.message));
+  });
+
+  it('prepends message from equalInAnyOrder', () => {
+    expect(
+      () => expect(true).to.deep.equalInAnyOrder(false, 'message'),
+    ).to.throw().and.satisfy(e => /^message:/.test(e.message));
+  });
+
+  it('prefers message from chain over expect', () => {
+    expect(
+      () => expect(true, 'message1').to.deep.equalInAnyOrder(false, 'message2'),
+    ).to.throw().and.satisfy(e => /^message2:/.test(e.message));
+  });
 });

--- a/src/tests/deepEqualInAnyOrder.js
+++ b/src/tests/deepEqualInAnyOrder.js
@@ -274,14 +274,14 @@ describe('equalInAnyOrder', () => {
 
   it('prepends message from expect', () => {
     expect(
-      () => expect(true, 'message').to.deep.equalInAnyOrder(false),
-    ).to.throw().and.satisfy(e => /^message:/.test(e.message));
+      () => expect(true, 'message1').to.deep.equalInAnyOrder(false),
+    ).to.throw().and.satisfy(e => /^message1:/.test(e.message));
   });
 
   it('prepends message from equalInAnyOrder', () => {
     expect(
-      () => expect(true).to.deep.equalInAnyOrder(false, 'message'),
-    ).to.throw().and.satisfy(e => /^message:/.test(e.message));
+      () => expect(true).to.deep.equalInAnyOrder(false, 'message1'),
+    ).to.throw().and.satisfy(e => /^message1:/.test(e.message));
   });
 
   it('prefers message from chain over expect', () => {


### PR DESCRIPTION
Issue #19 

I passed message from `expect(a, 'msg')` or from `equalInAnyOrder(b, 'msg')` to Assertion constructor, so it will be included in resulting assertion error:

`AssertionError: msg: expected true to not deeply equal true`

Message from last function call is preferred, checked on:

```
expect(42, 'msg1').to.be.a('string', 'msg2');
```

(msg2 is printed)