### PR TITLE
fix: Crash on objects that are null or have unmappable values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,16 @@ import sortAny from 'sort-any';
 
 const sortDeep = (object) => {
   if (!Array.isArray(object)) {
-    if (!(typeof object === 'object') || object === null) {
+    // == null checks for undefined as well as null.
+    if (object == null || (typeof object !== 'object')) {
       return object;
     }
 
-    return mapValues(object, sortDeep);
+    try {
+      return mapValues(object, sortDeep);
+    } catch {
+      return object;
+    }
   }
 
   return sortAny(object.map(sortDeep));


### PR DESCRIPTION
Likely fixes #35, but I'm not certain.  I have been using this patch in my projects for some time and am finally getting around to sending it back upstream.