### PR TITLE
Remove runtime dependency to lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "sinon-chai": "^3.6.0"
   },
   "dependencies": {
-    "lodash.mapvalues": "^4.6.0",
     "sort-any": "^4.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import mapValues from 'lodash.mapvalues';
 import sortAny from 'sort-any';
 
 const sortDeep = (object) => {
@@ -15,7 +14,7 @@ const sortDeep = (object) => {
     return object;
   }
 
-  return mapValues(object, sortDeep);
+  return Object.fromEntries(Object.entries(object).map(([k, v]) => [k, sortDeep(v)]));
 };
 
 module.exports = (chai, utils) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5131,11 +5131,6 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
 
-lodash.mapvalues@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
-  integrity sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=
-
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"


### PR DESCRIPTION
- upgraded to sort-any from 2x. to 4.x (latest 4.x has no dependency on lodash)
- refactored code to use native `Object.fromEntries(Object.entries().map(...))` instead of `lodash.mapvalues`

`Object.fromEntries()` is part of ES2019 and [available since Node12](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries#browser_compatibility)